### PR TITLE
Make all outputs filterable

### DIFF
--- a/woocommerce-grid-list-toggle.php
+++ b/woocommerce-grid-list-toggle.php
@@ -105,30 +105,26 @@ if ( in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', g
 
 			// Toggle button
 			function gridlist_toggle_button() {
-				?>
-					<nav class="gridlist-toggle">
-						<a href="#" id="grid" title="<?php _e('Grid view', 'woocommerce-grid-list-toggle'); ?>"><span class="dashicons dashicons-grid-view"></span> <em><?php _e( 'Grid view', 'woocommerce-grid-list-toggle' ); ?></em></a><a href="#" id="list" title="<?php _e('List view', 'woocommerce-grid-list-toggle'); ?>"><span class="dashicons dashicons-exerpt-view"></span> <em><?php _e( 'List view', 'woocommerce-grid-list-toggle' ); ?></em></a>
-					</nav>
-				<?php
+				
+				$grid_view = __( 'Grid view', 'woocommerce-grid-list-toggle' );
+				$list_view = __( 'List view', 'woocommerce-grid-list-toggle' );
+				
+				$output = sprintf( '<nav class="gridlist-toggle"><a href="#" id="grid" title="%1$s"><span class="dashicons dashicons-grid-view"></span> <em>%1$s</em></a><a href="#" id="list" title="%2$s"><span class="dashicons dashicons-exerpt-view"></span> <em>%2$s</em></a></nav>', $grid_view, $list_view );
+					
+				echo apply_filters( 'gridlist_toggle_button_output', $output, $grid_view, $list_view );
 			}
 
 			// Button wrap
 			function gridlist_buttonwrap_open() {
-				?>
-					<div class="gridlist-buttonwrap">
-				<?php
+				echo apply_filters( 'gridlist_button_wrap_start', '<div class="gridlist-buttonwrap">' );
 			}
 			function gridlist_buttonwrap_close() {
-				?>
-					</div>
-				<?php
+				echo apply_filters( 'gridlist_button_wrap_end', '</div>' );
 			}
 
 			// hr
 			function gridlist_hr() {
-				?>
-					<hr />
-				<?php
+				echo apply_filters( 'gridlist_hr', '<hr />' );
 			}
 
 			function gridlist_set_default_view() {
@@ -145,9 +141,9 @@ if ( in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', g
 
 			function gridlist_cat_desc( $category ) {
 				global $woocommerce;
-				echo '<div itemprop="description">';
+				echo apply_filters( 'gridlist_cat_desc_wrap_start', '<div itemprop="description">' );
 					echo $category->description;
-				echo '</div>';
+				echo apply_filters( 'gridlist_cat_desc_wrap_end', '</div>' );
 
 			}
 		}


### PR DESCRIPTION
It would be nice to be able to modify the outputs of this plugin. This PR creates the following filters to provide that extendability:
- `gridlist_toggle_button_output` - Filters the button output with variables for the translated 'Grid View' and 'List View' strings. See example below.
- `gridlist_button_wrap_start` - which defaults to: `<div class="gridlist-buttonwrap">`
- `gridlist_button_wrap_end` - which defaults to: `</div>`
- `gridlist_hr` - which defaults to: `<hr />`
- `gridlist_cat_desc_wrap_start` - which defaults to: `<div itemprop="description">`
- `gridlist_cat_desc_wrap_end` - which defaults to: `</div>`

These can be used, for instance, to replace the buttons with Font Awesome icons and switch their order:
```php
// Filter Gridlist button output
add_filter( 'gridlist_toggle_button_output', 'jdn_filter_gridlist_button_output', 10, 3 );

/**
 * Filter the Gridlist button output, use Font Awesome Icons instead.
 *
 * @param string $output The output value
 * @param string $grid_view The translated 'Grid View' string
 * @param string $list_view The Translated 'List View' string
 * 
 * @return string $output The filtered output value
 */
function jdn_filter_gridlist_button_output( $output, $grid_view, $list_view ) {
	return sprintf( '<nav class="gridlist-toggle"><a href="#" id="list" title="%2$s"><i class="fa fa-list"></i> <em>%2$s</em></a><a href="#" id="grid" title="%1$s"><i class="fa fa-th"></i> <em>%1$s</em></a></nav>', $grid_view, $list_view );
}
```