### PR TITLE
Add jQuery check to footer script.

### DIFF
--- a/woocommerce-grid-list-toggle.php
+++ b/woocommerce-grid-list-toggle.php
@@ -131,10 +131,14 @@ if ( in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', g
 				$default = get_option( 'wc_glt_default' );
 				?>
 					<script>
-						if (jQuery.cookie( 'gridcookie' ) == null) {
-					    	jQuery( 'ul.products' ).addClass( '<?php echo $default; ?>' );
-					    	jQuery( '.gridlist-toggle #<?php echo $default; ?>' ).addClass( 'active' );
-					    }
+					if ( 'function' == typeof(jQuery) ) {
+						jQuery(document).ready(function($) {
+							if ($.cookie( 'gridcookie' ) == null) {
+								$( 'ul.products' ).addClass( '<?php echo $default; ?>' );
+								$( '.gridlist-toggle #<?php echo $default; ?>' ).addClass( 'active' );
+							}
+						});
+					}
 					</script>
 				<?php
 			}


### PR DESCRIPTION
The script is printed without enqueuing it to WordPress scripts, and
I find it hard to remove gridlist_set_default_view function. This will
cause issue with Autoptimize plugin.

We can't be sure that jQuery is already there or not. Thus I suggest
to check it first.