### PR TITLE
Bump compatibility and release 1.2.2

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: jameskoster
 Tags: woocommerce, grid, list, products, ecommerce
 Requires at least: 4.0
-Tested up to: 4.9.5
-Stable tag: 1.2.1
+Tested up to: 5.2
+Stable tag: 1.2.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -64,6 +64,9 @@ function remove_gridlist_styles() {
 1. List view.
 
 == Changelog ==
+
+= 1.2.2 - 04/07/19 =
+* Bump 'Tested up to' for WP 5.2
 
 = 1.2.1 - 11/05/18 =
 * Hide debug info.

--- a/woocommerce-grid-list-toggle.php
+++ b/woocommerce-grid-list-toggle.php
@@ -2,11 +2,11 @@
 /*
 Plugin Name: WooCommerce Grid / List toggle
 Description: Adds a grid/list view toggle to product archives
-Version: 1.2.1
+Version: 1.2.2
 Author: jameskoster
 Author URI: http://jameskoster.co.uk
 Requires at least: 4.0
-Tested up to: 4.9.5
+Tested up to: 5.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: woocommerce-grid-list-toggle


### PR DESCRIPTION
As an extension listed on the [WooCommerce Extensions Store](https://woocommerce.com/products/grid-list-toggle/), I was surprised to see the warning on [WordPress.org page](https://wordpress.org/plugins/woocommerce-grid-list-toggle/):

> This plugin hasn’t been tested with the latest 3 major releases of WordPress. It may no longer be maintained or supported and may have compatibility issues when used with more recent versions of WordPress.

This PR bumps the _Tested up to_ to `5.2` and also releases a new minor version `1.2.2`.

Thanks,
Steve